### PR TITLE
Few fixes with persistent authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ module.exports = function (homebridge) {
           })
         })
     })
+
   }
 
   class VivintPlatform {
@@ -59,7 +60,7 @@ module.exports = function (homebridge) {
       this.api = api
 
       let VivintApi = VivintApiModule(config, log)
-      this.vivintApiPromise = VivintApi.login({username: config.username, password: config.password})
+      this.vivintApiPromise = VivintApi.login({username: config.username, password: config.password}, 1)
       let apiLoginRefreshSecs = config.apiLoginRefreshSecs || 1200 // once per 20 minutes default
 
 
@@ -129,5 +130,5 @@ module.exports = function (homebridge) {
     }
   }
 
-  homebridge.registerPlatform(PluginName, PlatformName, VivintPlatform);
+  homebridge.registerPlatform(PluginName, PlatformName, VivintPlatform)
 };

--- a/lib/device_set.js
+++ b/lib/device_set.js
@@ -361,7 +361,6 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
       super(accessory)
       this.service = accessory.getServiceByUUIDAndSubType(Service.LockMechanism)
       this.serviceb = accessory.getServiceByUUIDAndSubType(Service.BatteryService)
-      this.servicewss = accessory.getServiceByUUIDAndSubType(Service.WirelessSignalStrengthService)
 
       this.service
         .getCharacteristic(Characteristic.LockCurrentState)
@@ -376,14 +375,6 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
         this.serviceb
           .getCharacteristic(Characteristic.ChargingState)
           .updateValue(Characteristic.ChargingState.NOT_CHARGEABLE)
-      }
-      if(this.servicewss) {
-        this.servicewss
-          .getCharacteristic(Characteristic.WirelessSignalStrength)
-          .updateValue(100)
-        this.servicewss
-          .getCharacteristic(Characteristic.Name)
-          .updateValue("Wireless Signal Strength")
       }
     }
 
@@ -435,12 +426,6 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
         } else this.serviceb.getCharacteristic(Characteristic.StatusLowBattery).updateValue(Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL)
 
         this.serviceb.getCharacteristic(Characteristic.BatteryLevel).updateValue(this.lockBatteryLevelValue())
-      }
-
-      if (this.servicewss) {
-        this.servicewss
-          .getCharacteristic(Characteristic.WirelessSignalStrength)
-          .updateValue(this.data.wiss)
       }
     }
   }

--- a/lib/device_set.js
+++ b/lib/device_set.js
@@ -328,7 +328,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
         this.lastSensedMotion = Date.now()
       }
 
-      if (this.motionBatteryLevelValue()) {
+      if (this.motionBatteryLevelValue() && this.serviceb) {
         if (0 <= this.motionBatteryLevelValue() && this.motionBatteryLevelValue() <= config_LowBatteryLevel) {
           this.serviceb.getCharacteristic(Characteristic.StatusLowBattery).updateValue(Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW)
         } else this.serviceb.getCharacteristic(Characteristic.StatusLowBattery).updateValue(Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL)
@@ -716,6 +716,23 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
     constructor(accessory) {
       super(accessory)
 
+      let promiseSetter = function(fn) {
+        let boundDebounced = debounce(fn.bind(self), 500, {
+          leading: true
+        })
+        return (value, next) => {
+          boundDebounced(value).then(
+            (result) => {
+              next()
+            },
+            (failure) => {
+              log("failure " + failure)
+              next(failure)
+            }
+          )
+        }
+      }
+
       this.service = accessory.getServiceByUUIDAndSubType(Service.Lightbulb)
 
       this.service
@@ -726,7 +743,8 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
       this.service
         .getCharacteristic(Characteristic.Brightness)
         .on('get', (next) => next(null, this.switchBrightnessValue()))
-        .on('set', this.setBrightnessValue.bind(this))
+        .on('set', promiseSetter(this.setBrightnessValue.bind(this)))
+        //.on('set', this.setBrightnessValue.bind(this))
 
       this.last_val_s = null
       this.last_val = null

--- a/lib/device_set.js
+++ b/lib/device_set.js
@@ -344,7 +344,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
   }
   extend(MotionSensor, {
     appliesTo: (data) => {
-      return ((data.t == "wireless_sensor") && ((data.ec == 1249) || (data.ec == 1249)))
+      return ((data.t == "wireless_sensor") && (data.ec == 1249))
     },
     addServices: (accessory) => {
       accessory.addService(new Service.MotionSensor(accessory.context.name))
@@ -361,6 +361,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
       super(accessory)
       this.service = accessory.getServiceByUUIDAndSubType(Service.LockMechanism)
       this.serviceb = accessory.getServiceByUUIDAndSubType(Service.BatteryService)
+      this.servicewss = accessory.getServiceByUUIDAndSubType(Service.WirelessSignalStrengthService)
 
       this.service
         .getCharacteristic(Characteristic.LockCurrentState)
@@ -375,6 +376,14 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
         this.serviceb
           .getCharacteristic(Characteristic.ChargingState)
           .updateValue(Characteristic.ChargingState.NOT_CHARGEABLE)
+      }
+      if(this.servicewss) {
+        this.servicewss
+          .getCharacteristic(Characteristic.WirelessSignalStrength)
+          .updateValue(100)
+        this.servicewss
+          .getCharacteristic(Characteristic.Name)
+          .updateValue("Wireless Signal Strength")
       }
     }
 
@@ -426,6 +435,12 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
         } else this.serviceb.getCharacteristic(Characteristic.StatusLowBattery).updateValue(Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL)
 
         this.serviceb.getCharacteristic(Characteristic.BatteryLevel).updateValue(this.lockBatteryLevelValue())
+      }
+
+      if (this.servicewss) {
+        this.servicewss
+          .getCharacteristic(Characteristic.WirelessSignalStrength)
+          .updateValue(this.data.wiss)
       }
     }
   }
@@ -596,9 +611,8 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
 
 
     doorCurrentValue() {
-      //log("doorCurrentValue() this.data.s: " + this.data.s)
-
       switch(this.data.s){
+        case 0: // unknown state but this eliminates double notification
         case GARAGEDOOR_VIVINT_CLOSED:
           return Characteristic.CurrentDoorState.CLOSED
 
@@ -716,6 +730,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
     constructor(accessory) {
       super(accessory)
 
+      let self = this
       let promiseSetter = function(fn) {
         let boundDebounced = debounce(fn.bind(self), 500, {
           leading: true

--- a/lib/device_set.js
+++ b/lib/device_set.js
@@ -198,7 +198,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
     }
 
     contactBatteryLevelValue() {
-      return this.data.bl
+      return this.data.bl || 1
     }
 
     notify() {
@@ -320,7 +320,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
     }
 
     motionBatteryLevelValue() {
-      return this.data.bl
+      return this.data.bl || 1
     }
 
     notify() {
@@ -386,7 +386,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
     }
 
     lockBatteryLevelValue() {
-      return this.data.bl
+      return this.data.bl || 1
     }
 
     setLockTargetStateCharacteristic(targetState, next) {

--- a/lib/vivint_api.js
+++ b/lib/vivint_api.js
@@ -2,6 +2,23 @@ const request = require("request-promise-native")
 const PubNub = require('pubnub')
 const extend = require('util')._extend
 
+const fetchWithRetry = (url) => {
+  const fetchDataWithRetry = () => {
+    return request(url)
+      .then(result => {
+        return Promise.resolve(result)
+      })
+      .catch(err => {
+        return new Promise((resolve,reject) => {
+          setTimeout(() => {
+            return resolve(fetchDataWithRetry())
+          }, 5000)
+        })
+      })
+  }
+  return fetchDataWithRetry()
+}
+
 function VivintApiModule(config, log) {
   class VivintApi {
     constructor(creds, panelId, cookie, sessionInfo, systemInfo) {
@@ -64,7 +81,7 @@ function VivintApiModule(config, log) {
 
     putDevice(category, id, data) {
       //In case of Alarm panel there is no id because it is treated on the Panel level
-      let uriString = id != null ? 
+      let uriString = id != null ?
         "/" + category + "/" + id :
         "/" + category
 
@@ -83,16 +100,28 @@ function VivintApiModule(config, log) {
     }
   }
 
-  VivintApi.doAuth = (creds) => {
-    let loginRequest = request({
-      method: "POST",
-      url: "https://vivintsky.com/api/login",
-      body: JSON.stringify(creds)
-    })
-    return loginRequest.then((r) => {
-      let sessionInfo = JSON.parse(r)
-      let cookie = loginRequest.responseContent.headers["set-cookie"][0].split(";")[0]
+  VivintApi.doAuth = (creds, persistent = 0) => {
+    let loginRequest = null
 
+    if (persistent === 1) {
+      loginRequest = fetchWithRetry({
+        method: "POST",
+        url: "https://vivintsky.com/api/login",
+        body: JSON.stringify(creds),
+        resolveWithFullResponse: true
+      })
+    } else {
+      loginRequest = request({
+        method: "POST",
+        url: "https://vivintsky.com/api/login",
+        body: JSON.stringify(creds),
+        resolveWithFullResponse: true
+      })
+    }
+
+    return loginRequest.then((r) => {
+      let sessionInfo = JSON.parse(r.body)
+      let cookie = r.headers["set-cookie"][0].split(";")[0]
       return {sessionInfo: sessionInfo, cookie: cookie}
     })
   }
@@ -106,8 +135,8 @@ function VivintApiModule(config, log) {
     }).then(JSON.parse)
 
 
-  VivintApi.login = (creds) => {
-    return VivintApi.doAuth(creds).then((result) => {
+  VivintApi.login = (creds, persistent = 0) => {
+    return VivintApi.doAuth(creds, persistent).then((result) => {
       let sessionInfo = result.sessionInfo
       let cookie = result.cookie
       let panelId = sessionInfo.u.system[0].panid


### PR DESCRIPTION
- Initial login will continually retry until it is successful. Previously if the login failed, the error was uncaught and homebridge would exit. (i.e. if internet connection is currently unavailable)
- Fixed issue when battery level = 0
- Removed duplicate if statement for motion sensor
- Fixed redundant notification when garage door closes
- Fixed promise setter function to debounce changes with dimmer switches (experimental - no devices available to test)